### PR TITLE
Order Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop arguments correctly

### DIFF
--- a/BlazorSodium.Demo/Shared/BlazorSodiumComponent.razor.cs
+++ b/BlazorSodium.Demo/Shared/BlazorSodiumComponent.razor.cs
@@ -46,6 +46,8 @@ namespace BlazorSodium.Demo.Shared
          Console.WriteLine(Convert.ToHexString(paddedData));
          byte[] unpaddedData = Padding.Unpad(paddedData, 8);
          Console.WriteLine(Convert.ToHexString(unpaddedData));
+
+         Crypto_AEAD_ChaCha20Poly1305_Encrypt();
       }
 
       private string SaltString { get; set; }
@@ -79,6 +81,7 @@ namespace BlazorSodium.Demo.Shared
 
       protected string SecretStreamKey { get; set; }
       protected byte[] SecretStreamKeyBytes { get; set; }
+      
       [SupportedOSPlatform("browser")]
       protected void GenerateSecretStreamKey()
       {
@@ -91,6 +94,7 @@ namespace BlazorSodium.Demo.Shared
       protected string SecretStreamPlaintext { get; set; }
       protected string HexCiphertext { get; set; }
       protected string DecryptedText { get; set; }
+      
       [SupportedOSPlatform("browser")]
       protected void EncryptSecretStream()
       {
@@ -120,6 +124,18 @@ namespace BlazorSodium.Demo.Shared
             plaintextParts.Add(pullData.Message);
          }
          DecryptedText = Encoding.UTF8.GetString(plaintextParts.SelectMany(x => x).ToArray());
+      }
+
+      protected void Crypto_AEAD_ChaCha20Poly1305_Encrypt()
+      {
+         byte[] test = "It worked!"u8.ToArray();
+         byte[] nonce = RandomBytes.RandomBytes_Buf(AEAD.CHACHA20POLY1305_NPUB_BYTES);
+         byte[] key = RandomBytes.RandomBytes_Buf(AEAD.CHACHA20POLY1305_KEY_BYTES);
+         byte[] additionalData = [0x10];
+         byte[] encrypted = AEAD.Crypto_AEAD_ChaCha20Poly1305_Encrypt(test, nonce, key, additionalData);
+         byte[] decrypted = AEAD.Crypto_AEAD_ChaCha20Poly1305_Decrypt(encrypted, nonce, key, additionalData);
+         
+         Console.WriteLine($"Crypto_AEAD_ChaCha20Poly1305_Encrypt works: {Encoding.UTF8.GetString(decrypted)}");
       }
    }
 }

--- a/BlazorSodium/Sodium/AEAD.Interop.cs
+++ b/BlazorSodium/Sodium/AEAD.Interop.cs
@@ -69,7 +69,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, byte[] secretNonce, byte[] additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -82,7 +82,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, byte[] secretNonce, string additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -95,7 +95,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, byte[] secretNonce, byte[] additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -108,7 +108,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, byte[] secretNonce, string additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.

--- a/BlazorSodium/Sodium/AEAD.cs
+++ b/BlazorSodium/Sodium/AEAD.cs
@@ -65,7 +65,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
-         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, secretNonce: null, additionalData: additionalData, publicNonce: publicNonce, key: key);
+         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
       /// Encrypts a message using a secret key and public nonce.
@@ -77,7 +77,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
-         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, secretNonce: null, additionalData: additionalData, publicNonce: publicNonce, key: key);
+         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
       /// Encrypts a message using a secret key and public nonce.
@@ -89,7 +89,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
-         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, secretNonce: null, additionalData: additionalData, publicNonce: publicNonce, key: key);
+         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
       /// Encrypts a message using a secret key and public nonce.
@@ -101,7 +101,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(string message, byte[] publicNonce, byte[] key, string additionalData = null)
-         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, secretNonce: null, additionalData: additionalData, publicNonce: publicNonce, key: key);
+         => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
       /// Encrypts a message using a secret key and public nonce.


### PR DESCRIPTION
Looking at the libsodium.js wrapper for `crypto_aead_chacha20poly1305_encrypt`, which has not been updated for more than 4 years, it appears I implemented some of the interop arguments in the incorrect order.  `additional_data` comes before `secret_nonce`.

https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json