### PR TITLE
Fix AEAD typos and improve nullability of certain arguments

### DIFF
--- a/BlazorSodium/Sodium/AEAD.Interop.cs
+++ b/BlazorSodium/Sodium/AEAD.Interop.cs
@@ -69,7 +69,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -82,7 +82,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(byte[] message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -95,7 +95,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -108,7 +108,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(string message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -121,7 +121,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(byte[] message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -134,7 +134,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(byte[] message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -147,7 +147,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(string message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -160,7 +160,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(string message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -173,7 +173,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_decrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(byte[] secretNonce, byte[] ciphertext, byte[] additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(byte[]? secretNonce, byte[] ciphertext, byte[]? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -186,7 +186,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_decrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(byte[] secretNonce, byte[] ciphertext, string additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(byte[]? secretNonce, byte[] ciphertext, string? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -200,7 +200,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_decrypt_detached", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[] secretNonce, byte[] ciphertext, byte[] mac, byte[] additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[]? secretNonce, byte[] ciphertext, byte[] mac, byte[]? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -214,7 +214,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_decrypt_detached", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[] secretNonce, byte[] ciphertext, byte[] mac, string additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[]? secretNonce, byte[] ciphertext, byte[] mac, string? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -227,7 +227,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -240,7 +240,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -253,7 +253,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(string message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -266,7 +266,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(string message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -279,7 +279,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -292,7 +292,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -305,7 +305,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -318,7 +318,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_chacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -347,7 +347,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_decrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Interop(byte[] secretNonce, byte[] ciphertext, byte[] additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Interop(byte[]? secretNonce, byte[] ciphertext, byte[]? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -360,7 +360,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_decrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Interop(byte[] secretNonce, byte[] ciphertext, string additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Interop(byte[]? secretNonce, byte[] ciphertext, string? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -374,7 +374,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_decrypt_detached", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[] secretNonce, byte[] ciphertext, byte[] mac, byte[] additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[]? secretNonce, byte[] ciphertext, byte[] mac, byte[]? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -388,7 +388,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_decrypt_detached", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[] secretNonce, byte[] ciphertext, byte[] mac, string additionalData, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached_Interop(byte[]? secretNonce, byte[] ciphertext, byte[] mac, string? additionalData, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -401,7 +401,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -414,7 +414,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(byte[] message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -427,7 +427,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(string message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -440,7 +440,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt", "blazorSodium")]
-      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(string message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -453,7 +453,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -466,7 +466,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(byte[] message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -479,7 +479,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, byte[] additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, byte[]? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.
@@ -492,7 +492,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
       [JSImport("sodium.crypto_aead_xchacha20poly1305_ietf_encrypt_detached", "blazorSodium")]
-      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, string additionalData, byte[] secretNonce, byte[] publicNonce, byte[] key);
+      internal static partial JSObject Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(string message, string? additionalData, byte[]? secretNonce, byte[] publicNonce, byte[] key);
 
       /// <summary>
       /// Internal method.

--- a/BlazorSodium/Sodium/AEAD.cs
+++ b/BlazorSodium/Sodium/AEAD.cs
@@ -172,7 +172,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decypt(byte[] ciphertext, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, byte[] additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -184,7 +184,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>

--- a/BlazorSodium/Sodium/AEAD.cs
+++ b/BlazorSodium/Sodium/AEAD.cs
@@ -28,7 +28,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_decrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -40,7 +40,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_decrypt_detached.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Decrypt_Detached_Interop(secretNonce: null, ciphertext: detachedBox.Cipher, mac: detachedBox.MessageAuthenticationCode, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -52,7 +52,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_decrypt_detached.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Decrypt_Detached_Interop(secretNonce: null, ciphertext: detachedBox.Cipher, mac: detachedBox.MessageAuthenticationCode, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -64,7 +64,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -76,7 +76,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -88,7 +88,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(string message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -100,7 +100,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(string message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_Encrypt(string message, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -112,7 +112,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -127,7 +127,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, string? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -142,7 +142,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -157,7 +157,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, string? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_ChaCha20Poly1305_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -172,7 +172,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -184,7 +184,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -196,7 +196,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt_detached.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached_Interop(secretNonce: null, ciphertext: detachedBox.Cipher, mac: detachedBox.MessageAuthenticationCode, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -208,7 +208,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_decrypt_detached.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt_Detached_Interop(secretNonce: null, ciphertext: detachedBox.Cipher, mac: detachedBox.MessageAuthenticationCode, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -220,7 +220,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -232,7 +232,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -244,7 +244,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -256,7 +256,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_ChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -268,7 +268,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -283,7 +283,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, string? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -298,7 +298,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -313,7 +313,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_chacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_Chacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, string? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_Chacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -344,7 +344,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -356,7 +356,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt(byte[] ciphertext, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Interop(secretNonce: null, ciphertext: ciphertext, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -368,7 +368,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt_detached.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached_Interop(secretNonce: null, ciphertext: detachedBox.Cipher, mac: detachedBox.MessageAuthenticationCode, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -380,7 +380,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_decrypt_detached.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached(AEADBoxDetached detachedBox, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Decrypt_Detached_Interop(secretNonce: null, ciphertext: detachedBox.Cipher, mac: detachedBox.MessageAuthenticationCode, additionalData: additionalData, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -392,7 +392,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -404,7 +404,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(byte[] message, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -416,7 +416,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -428,7 +428,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt.json"/>
-      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static byte[] Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt(string message, byte[] publicNonce, byte[] key, string? additionalData = null)
          => Crypto_AEAD_XChaCha20Poly1305_IETF_Encrypt_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
 
       /// <summary>
@@ -440,7 +440,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -455,7 +455,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(byte[] message, byte[] publicNonce, byte[] key, string? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -470,7 +470,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, byte[] additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, byte[]? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);
@@ -485,7 +485,7 @@ namespace BlazorSodium.Sodium
       /// <param name="additionalData">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_aead_xchacha20poly1305_ietf_encrypt_detached.json"/>
-      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, string additionalData = null)
+      public static AEADBoxDetached Crypto_AEAD_XChacha20Poly1305_Encrypt_Detached(string message, byte[] publicNonce, byte[] key, string? additionalData = null)
       {
          JSObject jsObject = Crypto_AEAD_XChacha20Poly1305_IETF_Encrypt_Detached_Interop(message: message, additionalData: additionalData, secretNonce: null, publicNonce: publicNonce, key: key);
          return AEADBoxDetached.FromJavaScript(jsObject);


### PR DESCRIPTION
Rename `Crypto_AEAD_ChaCha20Poly1305_IETF_Decypt` to `Crypto_AEAD_ChaCha20Poly1305_IETF_Decrypt`.  Notice the missing `r` in `Decypt`.

`AdditionalData` and `SecretNonce` arguments are properly nullable, now.