### PR TITLE
Better nullability support in GenericHash methods

### DIFF
--- a/BlazorSodium/BlazorSodium.csproj
+++ b/BlazorSodium/BlazorSodium.csproj
@@ -16,8 +16,8 @@
       <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
       <IncludeSymbols>True</IncludeSymbols>
       <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-      <Version>1.3.1</Version>
-      <PackageVersion>1.3.1</PackageVersion>
+      <Version>1.3.2</Version>
+      <PackageVersion>1.3.2</PackageVersion>
       <LangVersion>12</LangVersion>
    </PropertyGroup>
 

--- a/BlazorSodium/Sodium/GenericHash.Interop.cs
+++ b/BlazorSodium/Sodium/GenericHash.Interop.cs
@@ -13,7 +13,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_generichash.json"/>
       [JSImport("sodium.crypto_generichash", "blazorSodium")]
-      internal static partial byte[] Crypto_GenericHash_Interop([JSMarshalAs<JSType.Number>] long hashLength, byte[] message, byte[] key = null);
+      internal static partial byte[] Crypto_GenericHash_Interop([JSMarshalAs<JSType.Number>] long hashLength, byte[] message, byte[]? key = null);
 
       /// <summary>
       /// Internal method.
@@ -24,7 +24,7 @@ namespace BlazorSodium.Sodium
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_generichash.json"/>
       [JSImport("sodium.crypto_generichash", "blazorSodium")]
-      internal static partial byte[] Crypto_GenericHash_Interop([JSMarshalAs<JSType.Number>] long hashLength, string message, byte[] key = null);
+      internal static partial byte[] Crypto_GenericHash_Interop([JSMarshalAs<JSType.Number>] long hashLength, string message, byte[]? key = null);
 
       /* Missing from the sodium module
       /// <summary>

--- a/BlazorSodium/Sodium/GenericHash.cs
+++ b/BlazorSodium/Sodium/GenericHash.cs
@@ -14,7 +14,7 @@ namespace BlazorSodium.Sodium
       /// <param name="key">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_generichash.json"/>
-      public static byte[] Crypto_GenericHash(uint hashLength, byte[] message, byte[] key = null)
+      public static byte[] Crypto_GenericHash(uint hashLength, byte[] message, byte[]? key = null)
          => Crypto_GenericHash_Interop(hashLength, message, key);
 
       /// <summary>
@@ -25,7 +25,7 @@ namespace BlazorSodium.Sodium
       /// <param name="key">Optional.</param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_generichash.json"/>
-      public static byte[] Crypto_GenericHash(uint hashLength, string message, byte[] key = null)
+      public static byte[] Crypto_GenericHash(uint hashLength, string message, byte[]? key = null)
          => Crypto_GenericHash_Interop(hashLength, message, key);
 
       /// <summary>
@@ -45,7 +45,7 @@ namespace BlazorSodium.Sodium
       /// <param name="key"></param>
       /// <returns></returns>
       /// <see cref="https://github.com/jedisct1/libsodium.js/blob/master/wrapper/symbols/crypto_generichash_init.json"/>
-      public static StateAddress Crypto_GenericHash_Init(uint hashLength, byte[] key = null)
+      public static StateAddress Crypto_GenericHash_Init(uint hashLength, byte[]? key = null)
       {
          int stateAddress = Crypto_GenericHash_Init_Interop(key, hashLength);
          return new StateAddress(stateAddress);


### PR DESCRIPTION
The optional `key` argument in the various `GenericHash` methods should be nullable.